### PR TITLE
Update conda installation instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -18,7 +18,7 @@ installed](https://bioconda.github.io/index.html), installing antiSMASH is as
 easy as running
 
 ```bash
-conda create -n antismash antismash
+conda create -n antismash antismash biopython=1.77
 conda activate antismash
 download-antismash-databases
 conda deactivate


### PR DESCRIPTION
Currently you need to specify the biopython version (1.77) when installing antismash via conda. For more info see here: https://github.com/antismash/antismash/issues/293#issuecomment-692057939

I see this has been fixed in master, but not in a release. So currently this changed is needed to install antismash
